### PR TITLE
Add alert text for zooming in to see predicted observations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useFilterStore } from "@/store/filterStore";
 import { SatellitePopup } from "@/components/SatellitePopup";
 import { Header } from "@/components/Header";
 import { SidebarContent } from "@/components/SidebarContent";
+import { ZoomPrompt } from "@/components/ZoomPrompt";
 import { loadMapData } from "@/utils/mapUtils";
 
 interface ClickedFeature {
@@ -30,6 +31,7 @@ function App() {
   const [clickedFeature, setClickedFeature] = useState<ClickedFeature | null>(
     null
   );
+  const [zoom, setZoom] = useState(1);
   const mapRef = useRef<MapRef | null>(null); // MapLibre map ref
 
   const { metadata, timeRange, mapFilter, setMetadata, setTimeRange } =
@@ -80,12 +82,13 @@ function App() {
             initialViewState={{
               longitude: -111.7,
               latitude: 39.3,
-              zoom: 1,
+              zoom: zoom,
             }}
             style={{ width: "100%", height: "100%" }}
             mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
             projection={{ type: "globe" }}
             onClick={handleMapClick}
+            onMove={(evt) => setZoom(evt.viewState.zoom)}
             interactiveLayerIds={["satellite_paths"]}
             maxZoom={13}
           >
@@ -126,6 +129,7 @@ function App() {
               trackUserLocation={true}
             />
           </Map>
+          <ZoomPrompt visible={zoom < 2.5} />
         </div>
 
         {/* Mobile Controls */}

--- a/src/components/ZoomPrompt.tsx
+++ b/src/components/ZoomPrompt.tsx
@@ -1,0 +1,22 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { ZoomIn } from "lucide-react";
+
+interface ZoomPromptProps {
+  visible: boolean;
+}
+
+export function ZoomPrompt({ visible }: ZoomPromptProps) {
+  return (
+    <div
+      className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none
+        transition-opacity duration-300 ${
+          visible ? "opacity-100" : "opacity-0"
+        }`}
+    >
+      <Alert className="backdrop-blur-sm shadow-2xl">
+        <ZoomIn className="" />
+        <AlertDescription>Zoom in to see predicted EO passes.</AlertDescription>
+      </Alert>
+    </div>
+  );
+}


### PR DESCRIPTION
Currently, it's not obvious that predicted passes are available on app load, since tiles aren't displayed until the map is zoomed in, and the list of upcoming observations is only displayed when less than 100 meet the filter/geographic restrictions.

This PR adds an `<Alert>` component, visible from zoom 0-2.5, alerting the user to zoom in to see upcoming observations.

> [!NOTE] 
> I did have help with Claude on the css for the fade in/out — not sure if that's the best way to implement it.

https://github.com/user-attachments/assets/5995b7a9-68ea-4a6e-837f-7f4bd2e6066c 

https://github.com/user-attachments/assets/ede29ade-881e-4a8e-a547-cac8b31a0152