### PR TITLE
Handle 404 errors for satellites with no GP data from Celestrak

### DIFF
--- a/scripts/generate_satellite_paths.py
+++ b/scripts/generate_satellite_paths.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import os
 import subprocess
-import sys
 from datetime import datetime, timedelta, timezone
 
 import geopandas as gpd

--- a/scripts/generate_satellite_paths.py
+++ b/scripts/generate_satellite_paths.py
@@ -114,7 +114,10 @@ async def fetch_tle(client, request):
     except httpx.HTTPStatusError as e:
         # Celestrak returns 404 (instead of 200 with a "no GP data" body) for
         # catalog numbers with no GP data, e.g. decayed/deorbited satellites.
-        if e.response.status_code == 404 and "no gp data found" in e.response.text.lower():
+        if (
+            e.response.status_code == 404
+            and "no gp data found" in e.response.text.lower()
+        ):
             print(f"  No GP data found for NORAD {norad_id}")
             return {
                 "norad_id": norad_id,

--- a/scripts/generate_satellite_paths.py
+++ b/scripts/generate_satellite_paths.py
@@ -113,6 +113,17 @@ async def fetch_tle(client, request):
             "content": response.text,
         }
     except httpx.HTTPStatusError as e:
+        # Celestrak returns 404 (instead of 200 with a "no GP data" body) for
+        # catalog numbers with no GP data, e.g. decayed/deorbited satellites.
+        if e.response.status_code == 404 and "no gp data found" in e.response.text.lower():
+            print(f"  No GP data found for NORAD {norad_id}")
+            return {
+                "norad_id": norad_id,
+                "url": url,
+                "success": False,
+                "no_gp": True,
+                "content": "",
+            }
         print(
             f"  Failed to fetch NORAD {norad_id} (HTTP error: {e.response.status_code})"
         )
@@ -270,10 +281,10 @@ print(f"Fetch status saved to: {fetch_status_path}")
 
 if success_rate <= 0.9:
     print(
-        "TLE fetch success rate for active satellites did not exceed 90%. "
-        "Aborting tile generation to prevent incomplete deploy."
+        "WARNING: TLE fetch success rate for active satellites did not exceed 90%. "
+        "Deploying with the satellites that were fetched; "
+        "see satellite_fetch_status.json for details."
     )
-    sys.exit(1)
 
 # Set up the time range for the prediction
 ts = load.timescale()


### PR DESCRIPTION
Fixes https://github.com/developmentseed/eo-predictor/issues/120

Currently, the generation script is failing due to a less than 90% theshold of succesfully-fetched data.

This appears to occur when satellites are no longer operational, rather than issues with the upstream data provider.

Instead of guarding against temporary data issues, current logic blocks deployments, thus leaving outdated deployed data.

This PR notifies the success rate via the success rate component on the frontend without blocking deployments.