### PR TITLE
Fix broken deploy and dependabot CI checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
           run_install: false
 
       - name: Install frontend dependencies

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,10 @@
 .mypy_cache
 .venv
 
+# Dependabot regenerates this without running Prettier, so its formatting
+# never matches what `prettier --check` expects.
+pnpm-lock.yaml
+
 # Reusable/called workflow files must stay byte-identical to the default
 # branch (GitHub skips "modified workflow" validation otherwise), so don't
 # let Prettier reformat them out from under that constraint.

--- a/scripts/generate_satellite_paths.py
+++ b/scripts/generate_satellite_paths.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import subprocess
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import geopandas as gpd
 import httpx
@@ -266,7 +266,7 @@ fetch_status = {
     "noGpDataNoradIds": no_gp_norad_ids,
     "failedFetchNoradIds": failed_fetch_norad_ids,
     "successRate": success_rate,
-    "lastUpdated": datetime.now(timezone.utc).isoformat(),
+    "lastUpdated": datetime.now(UTC).isoformat(),
 }
 
 fetch_status_path = os.path.join(public_dir, "satellite_fetch_status.json")
@@ -290,7 +290,7 @@ if success_rate <= 0.9:
 
 # Set up the time range for the prediction
 ts = load.timescale()
-now = datetime.now(timezone.utc)
+now = datetime.now(UTC)
 time_1 = now
 time_2 = now + timedelta(days=2)
 
@@ -321,7 +321,7 @@ def is_daytime(lat_degrees, lon_degrees, observation_time):
 
     # Calculate solar position relative to the location
     astrometric = location.at(t).observe(sun)
-    alt, az, distance = astrometric.apparent().altaz()
+    alt, _az, _distance = astrometric.apparent().altaz()
 
     # Return True if sun is above horizon (elevation > 0°)
     return alt.degrees > 0
@@ -465,7 +465,7 @@ else:
         "spatial_resolution_ranges": list(set(spatial_resolution_ranges)),
         "minTime": path_gdf["start_time"].min().isoformat(),
         "maxTime": path_gdf["end_time"].max().isoformat(),
-        "lastUpdated": datetime.now(timezone.utc).isoformat(),
+        "lastUpdated": datetime.now(UTC).isoformat(),
         "tilesUrl": "/tiles/{z}/{x}/{y}.pbf",
     }
 
@@ -502,7 +502,8 @@ else:
             tiles_dir,
             geojson_path,
             "--force",
-        ]
+        ],
+        check=False,
     )
     print(f"\nSuccessfully generated tiles in {tiles_dir}")
 

--- a/scripts/validate_satellites.py
+++ b/scripts/validate_satellites.py
@@ -14,7 +14,8 @@ Usage: uv run validate_satellites.py
 import json
 import os
 from collections import defaultdict
-from typing import Annotated, List, Literal, Optional
+from typing import Annotated, Literal
+
 from pydantic import BaseModel, Field, HttpUrl
 
 
@@ -42,16 +43,16 @@ class SatelliteConstellation(BaseModel):
     tasking: bool = Field(
         description="Whether satellites can be tasked (true) or are pre-programmed (false)"
     )
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl | None = Field(
         None, description="Optional link to constellation information page"
     )
-    norad_ids: List[Annotated[int, Field(gt=0)]] = Field(
+    norad_ids: list[Annotated[int, Field(gt=0)]] = Field(
         min_length=1, description="Array of NORAD catalog numbers"
     )
-    data_repo_type: Optional[Literal["STAC", "API", "portal", "bucket", "other"]] = (
-        Field(None, description="Type of data repository. STAC is preferred.")
+    data_repo_type: Literal["STAC", "API", "portal", "bucket", "other"] | None = Field(
+        None, description="Type of data repository. STAC is preferred."
     )
-    data_repo_url: Optional[HttpUrl] = Field(
+    data_repo_url: HttpUrl | None = Field(
         None,
         description="Link to get data. Preferred STAC catalog, can also be API, portal, bucket or other",
     )


### PR DESCRIPTION
## Summary
- Bump `pnpm/action-setup` in `deploy.yml` from 9 to 10, matching `ci.yml`. Version 9 doesn't understand a `pnpm-workspace.yaml` without a `packages:` key (added in #130), so every scheduled deploy since has failed at `pnpm install` with `packages field missing or empty`.
- Add `pnpm-lock.yaml` to `.prettierignore`. Dependabot regenerates the lockfile without running Prettier, so `pnpm format:check` has been failing on every npm dependabot PR since May (#119, #118, #117, #116, #115).
- Fix the ruff 0.16.1 lint errors introduced on `main` by #126 (unused unpacked variables, `datetime.UTC` alias, explicit `subprocess.run(check=...)`, and a missing executable bit matching the shebang in `validate_satellites.py`).

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run python validate_satellites.py` passes
- [x] `pnpm format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)